### PR TITLE
Add text domain support for translations

### DIFF
--- a/kiss-outgoing-links.php
+++ b/kiss-outgoing-links.php
@@ -5,11 +5,21 @@ Description: Scans all posts (including custom post types) for outgoing HTTP/HTT
 Version: 1.0.0
 Author: KISS Plugins | Neochrome, Inc.
 License: GPL‑2.0‑or‑later
+Text Domain: ols
+Domain Path: /languages
 */
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly.
 }
+
+/**
+ * Load plugin translations.
+ */
+function ols_load_textdomain() {
+    load_plugin_textdomain( 'ols', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'init', 'ols_load_textdomain' );
 
 /**
  * Register the admin menu entry.


### PR DESCRIPTION
## Summary
- add text domain and domain path headers
- load plugin textdomain on init
- add empty `languages/` directory for future translations

## Testing
- `php -l kiss-outgoing-links.php` *(fails: `php: command not found`)*