### PR TITLE
Add view filters by post type

### DIFF
--- a/kiss-outgoing-links.php
+++ b/kiss-outgoing-links.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: KISS Outgoing Links Scanner
 Description: Scans all posts (including custom post types) for outgoing HTTP/HTTPS links and lists them in an admin‑side table you can copy to the clipboard.
-Version: 1.0.0
+Version: 1.2.0
 Author: KISS Plugins | Neochrome, Inc.
 License: GPL‑2.0‑or‑later
 */
@@ -35,7 +35,7 @@ function ols_enqueue_admin_assets( $hook ) {
     }
 
     // Our tiny JS lives inline – no extra files needed for now.
-    wp_add_inline_script( 'jquery-core', "\n(function($){\n    $('#ols-copy-btn').on('click', function(){\n        var table = document.getElementById('ols-results');\n        if (!table) { return; }\n        var txt = '';\n        for (var i = 0; i < table.rows.length; i++) {\n            var cells = table.rows[i].cells;\n            var row = [];\n            for (var j = 0; j < cells.length; j++) {\n                row.push(cells[j].innerText.replace(/\n|\r|\t/g, ' '));\n            }\n            txt += row.join('\t') + '\n';\n        }\n        navigator.clipboard.writeText(txt).then(function(){\n            alert('Table copied to clipboard!');\n        });\n    });\n})(jQuery);\n" );
+    wp_add_inline_script( 'jquery-core', "\n(function($){\n    $('#ols-copy-btn').on('click', function(){\n        var table = document.getElementById('ols-results');\n        if (!table) { return; }\n        var txt = '';\n        for (var i = 0; i < table.rows.length; i++) {\n            var cells = table.rows[i].cells;\n            var row = [];\n            for (var j = 0; j < cells.length; j++) {\n                row.push(cells[j].innerText.replace(/\n|\r|\t/g, ' '));\n            }\n            txt += row.join('\t') + '\n';\n        }\n        navigator.clipboard.writeText(txt).then(function(){\n            alert('Table copied to clipboard!');\n        });\n    });\n    $('.ols-filter').on('change', function(){\n        var slug = $(this).data('pt');\n        var show = $(this).is(':checked');\n        $('#ols-results tbody tr').each(function(){\n            if ($(this).data('pt') == slug) {\n                $(this).toggle(show);\n            }\n        });\n    });\n})(jQuery);\n" );
 }
 add_action( 'admin_enqueue_scripts', 'ols_enqueue_admin_assets' );
 
@@ -68,20 +68,42 @@ function ols_render_admin_page() {
         <?php if ( ! empty( $results ) ) : ?>
             <h2 style="margin-top:2rem;"><?php esc_html_e( 'Scan Results', 'ols' ); ?></h2>
             <button id="ols-copy-btn" class="button"><?php esc_html_e( 'Copy to Clipboard', 'ols' ); ?></button>
+            <?php
+            $pt_labels = array();
+            foreach ( $results as $row ) {
+                if ( empty( $pt_labels[ $row['post_type'] ] ) ) {
+                    $obj = get_post_type_object( $row['post_type'] );
+                    $pt_labels[ $row['post_type'] ] = $obj ? $obj->labels->singular_name : $row['post_type'];
+                }
+            }
+            ?>
+            <div id="ols-filters" style="margin-top:1rem;">
+                <?php foreach ( $pt_labels as $slug => $label ) : ?>
+                    <label style="margin-right:1rem;"><input type="checkbox" class="ols-filter" data-pt="<?php echo esc_attr( $slug ); ?>" checked="checked" /> <?php echo esc_html( $label ); ?></label>
+                <?php endforeach; ?>
+            </div>
             <table class="widefat fixed striped" id="ols-results" style="margin-top:1rem;">
                 <thead>
                     <tr>
                         <th><?php esc_html_e( 'Outgoing URL', 'ols' ); ?></th>
                         <th><?php esc_html_e( 'Text', 'ols' ); ?></th>
                         <th><?php esc_html_e( 'Approx. location in post %', 'ols' ); ?></th>
+                        <th><?php esc_html_e( 'Post/Page Title', 'ols' ); ?></th>
+                        <th><?php esc_html_e( 'Actions', 'ols' ); ?></th>
                     </tr>
                 </thead>
                 <tbody>
                 <?php foreach ( $results as $row ) : ?>
-                    <tr>
+                    <tr data-pt="<?php echo esc_attr( $row['post_type'] ); ?>">
                         <td><a href="<?php echo esc_url( $row['url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $row['url'] ); ?></a></td>
                         <td><?php echo esc_html( $row['text'] ); ?></td>
                         <td><?php echo esc_html( $row['percent'] ); ?>%</td>
+                        <td><?php echo esc_html( mb_strimwidth( get_the_title( $row['post_id'] ), 0, 40, '...' ) ); ?></td>
+                        <td>
+                            <a href="<?php echo esc_url( get_permalink( $row['post_id'] ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'View', 'ols' ); ?></a>
+                            |
+                            <a href="<?php echo esc_url( get_edit_post_link( $row['post_id'] ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Edit', 'ols' ); ?></a>
+                        </td>
                     </tr>
                 <?php endforeach; ?>
                 </tbody>
@@ -94,7 +116,13 @@ function ols_render_admin_page() {
 /**
  * Perform the heavy‑lifting: scan posts and extract links.
  *
- * @return array[] {\n *     @type string $url     The outbound URL.\n *     @type string $text    Anchor text.\n *     @type int    $percent Position of the link within the post, rounded.\n * }
+ * @return array[] {
+ *     @type string $url     The outbound URL.
+ *     @type string $text    Anchor text.
+ *     @type int    $percent Position of the link within the post, rounded.
+ *     @type int    $post_id   ID of the post containing the link.
+ *     @type string $post_type Post type of the post.
+ * }
  */
 function ols_perform_scan() {
     global $wpdb;
@@ -139,9 +167,11 @@ function ols_perform_scan() {
                 $percent  = $len ? round( ( $pos / $len ) * 100 ) : 0;
 
                 $results[] = array(
-                    'url'     => $href,
-                    'text'    => $anchor_text,
-                    'percent' => $percent,
+                    'url'       => $href,
+                    'text'      => $anchor_text,
+                    'percent'   => $percent,
+                    'post_id'   => $post->ID,
+                    'post_type' => $post->post_type,
                 );
             }
         }


### PR DESCRIPTION
## Summary
- bump version to 1.2.0
- include post type in scan results
- add Post/Page Title column and show permalink/edit actions
- add filter checkboxes to dynamically show/hide rows per post type
- include small JS for filters

## Testing
- `php -l kiss-outgoing-links.php` *(fails: command not found)*